### PR TITLE
implemented input field with overwrite button for in- and export data

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -303,3 +303,63 @@ strong {
     opacity: 1;
   }
 }
+
+/* Remove this and load from bootstrap */
+
+.form-control {
+    display: block;
+    width: 100%;
+    height: 34px;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.42857143;
+    color: #555;
+    background-color: #fff;
+    background-image: none;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+    -webkit-transition: border-color ease-in-out .15s,-webkit-box-shadow ease-in-out .15s;
+    -o-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+    transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+}
+
+.input-group {
+    position: relative;
+    display: table;
+    border-collapse: separate;
+}
+
+.input-group .form-control {
+    position: relative;
+    z-index: 2;
+    float: left;
+    width: 100%;
+    margin-bottom: -11px;
+}
+
+.input-group .form-control:first-child, .input-group-addon:first-child, .input-group-btn:first-child>.btn, .input-group-btn:first-child>.btn-group>.btn, .input-group-btn:first-child>.dropdown-toggle, .input-group-btn:last-child>.btn-group:not(:last-child)>.btn, .input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.input-group .form-control:last-child, .input-group-addon:last-child, .input-group-btn:first-child>.btn-group:not(:first-child)>.btn, .input-group-btn:first-child>.btn:not(:first-child), .input-group-btn:last-child>.btn, .input-group-btn:last-child>.btn-group>.btn, .input-group-btn:last-child>.dropdown-toggle {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.input-group .form-control, .input-group-addon, .input-group-btn {
+    display: table-cell;
+}
+
+.input-group-btn:last-child>.btn, .input-group-btn:last-child>.btn-group {
+    z-index: 2;
+    margin-left: -1px;
+}
+
+.input-group-btn>.btn {
+    position: relative;
+}
+
+/* Remove end */

--- a/js/main.js
+++ b/js/main.js
@@ -102,6 +102,19 @@ OWI.controller('SettingsCtrl', ["$rootScope", "$uibModalInstance", "StorageServi
     }
   }
 
+  this.data = angular.toJson(StorageService.getData());
+
+  this.importData = function(data) {
+    try {
+      data = angular.fromJson(data);
+      //TODO: implement check data correct
+      StorageService.setData(data);
+      location.reload();
+    } catch (e) {
+      this.importDataError = 'Import not successful :(';
+    }
+  }
+
   this.selectTheme = function(what) {
     this.currentTheme = what
     StorageService.setSetting('currentTheme', what)

--- a/templates/modals/settings.html
+++ b/templates/modals/settings.html
@@ -23,6 +23,21 @@
       <p>Disable or enable showing HD videos of Highlight Intros and Emotes</p>
       <button class="btn btn-primary" type="button" ng-click="settings.toggleSetting('hdVideos')">{{settings.hdVideos ? 'Disable' : 'Enable'}}</button>
     </div>
+    <div class="setting">
+      <h3>Import/Export Data</h3>
+      <p>Copy and paste this string into your other browser or store it in a file for backup. You can also input your export and import it with the overwrite button.</p>
+      <div class="input-group">
+        <input type="text" class="form-control" ng-model="settings.data" size="100" spellcheck="false">
+        <span class="input-group-btn">
+          <button class="btn btn-warning" type="button" ng-click="settings.importData(settings.data)">Overwrite data!</button>
+        </span>
+      </div>
+      <div ng-show="settings.importDataError" style="padding: 7px 0 0 5px; color: #a94442;" role="alert">
+          <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+          <span class="sr-only">Error:</span>
+          {{settings.importDataError}}
+      </div>
+    </div>
   </div>
   <div class="modal-footer">
     <button class="btn btn-primary" type="button" ng-click="settings.close()">Close</button>


### PR DESCRIPTION
#16 

I have written a function importData in SettingsCtrl that can be improved by throwing an error if the data doesn't validate.

Also please notice that I have copied some code from bootstrap to reenable input-fields design with button
please remove this and take the original from bootstrap into your bootstrap.min.css

I have added spellcheck="false" to the input because otherwise it is horrible slow with large json.