### PR TITLE
Added functionality for hiding owned items.

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -4,6 +4,7 @@ OWI.controller('MainCtrl', ["$rootScope", "$q", "$document", "$uibModal", "DataS
   this.currentDate = Date.now();
   this.showSidebar = false;
   this.showNav = false;
+  this.showOwnedItems = true;
   this.noSupportMsg = CompatibilityService.noSupportMsg;
   this.totals = CostAndTotalService;
 
@@ -74,6 +75,22 @@ OWI.controller('MainCtrl', ["$rootScope", "$q", "$document", "$uibModal", "DataS
         $document.on('click', documentClicked);
       }, 0);
     }
+  };
+  
+  this.toggleOwnedItemVisibility = function() {
+      this.showOwnedItems = !this.showOwnedItems;
+      var checkBoxes = document.querySelectorAll("input[type='checkbox']");
+      var visibility = ""; //Default display value for the divs
+      
+      if (!this.showOwnedItems) {
+        visibility = "none";
+      }
+      
+      for(var i = 0; i < checkBoxes.length; i++){
+        if(checkBoxes[i].checked) {
+            checkBoxes[i].parentElement.style.display = visibility;
+        }
+      }
   };
 
   this.openSettings = function() {

--- a/templates/header-event.html
+++ b/templates/header-event.html
@@ -1,3 +1,4 @@
+<div class="event-selector" ng-click="$ctrl.toggleOwnedItemVisibility()"><h2>Show/Hide Owned</h2></div>
 <div ng-show="$ctrl.item.dates.end > $ctrl.currentDate" class="event-active">
   <h2>Event should end on {{$ctrl.item.dates.end | date:'MMM d'}} local time</h2>
   <h3>Be sure to get everything you want by {{$ctrl.item.dates.end - 86400000 | date:'MMM d'}} to be safe!</h3>


### PR DESCRIPTION
Added a button to the event pages that allows for the hiding of owned (checked) items. This makes it easier to see what you're missing from the event.

Button currently just uses the styling of the "event-selector" class, and the showing/hiding of the items just uses the document.querySelectorAll() method and iterates over all the checkboxes on the page, showing/hiding the parent element if the box is checked.