### PR TITLE
Fix total calculation, now count standardItems

### DIFF
--- a/js/services.js
+++ b/js/services.js
@@ -185,9 +185,7 @@ OWI.factory('CostAndTotalService', ["DataService", "StorageService", "$q", "$tim
               s_hero.groups[item.group] = true;
             }
 
-            if (item.standardItem) continue;
-
-            var isSelected = DataService.checked[item.hero || hero.id][type][item.id];
+            var isSelected = DataService.checked[item.hero || hero.id][type][item.id] || item.standardItem;
             var isSpecialItem = 'achievement' in item && item.achievement !== true && heroId !== 'all'
 
             // Unselected special items (blizzard unlocks, origin skins, mercy bcrf items) dont count unless unlocked


### PR DESCRIPTION
Hi, 

StandardItems were not counted in totals. I think I fixed it but I'm not sure on how this may impacts the rest of the app.

fix https://github.com/Js41637/Overwatch-Item-Tracker/issues/275

