### PR TITLE
Transition error handling fix

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -245,7 +245,7 @@ OWI.run(["$transitions", "$state", "DataService", function($transitions, $state,
   $transitions.onError({}, function(error) {
     if (error.error().detail === 'INVALID_EVENT') {
       $state.go('events', { id: Data.currentEvent });
-    } else if (error.error().type !== RejectType.IGNORED) {
+    } else if (error.error().type !== 5) {
       $state.go('home');
     }
   })

--- a/js/app.js
+++ b/js/app.js
@@ -243,10 +243,10 @@ OWI.config(['$stateProvider', '$urlRouterProvider', function($stateProvider, $ur
 // Listen for state change errors such as routing to an invalid hero and redirect
 OWI.run(["$transitions", "$state", "DataService", function($transitions, $state, Data) {
   $transitions.onError({}, function(error) {
-    if (error.error().detail === 'INVALID_HERO') {
-      $state.go('home');
-    } else {
+    if (error.error().detail === 'INVALID_EVENT') {
       $state.go('events', { id: Data.currentEvent });
+    } else {
+      $state.go('home');
     }
   })
 }]);

--- a/js/app.js
+++ b/js/app.js
@@ -245,7 +245,7 @@ OWI.run(["$transitions", "$state", "DataService", function($transitions, $state,
   $transitions.onError({}, function(error) {
     if (error.error().detail === 'INVALID_EVENT') {
       $state.go('events', { id: Data.currentEvent });
-    } else {
+    } else if (error.error().type !== RejectType.IGNORED) {
       $state.go('home');
     }
   })


### PR DESCRIPTION
`INVALID_HERO` does not seem to be a valid error detail since https://github.com/Js41637/Overwatch-Item-Tracker/commit/c745557586f8f1e4ed0262ba8b659c76b1d0515a, so specifically handle `INVALID_EVENT` instead and default to transitioning to home state.
Also don't handle ignored transitions, so that clicking to transition to a page you're already on doesn't redirect to home page (would previously redirect to current event page; Fixes #289) or cause an infinite loop on the home page (previously on the current event page; Fixes #288).